### PR TITLE
feat: option to skip unsupported asset files

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ The user associated with the token must have push permission to the repository.
 | `GITEA_TOKEN`   | **Required.** The token used to authenticate with Gitea. |
 | `GITEA_URL`       | **Required.** The URL to your Gitea instance.          |
 | `GITEA_PREFIX` | The Gitea API prefix. (default: /api/v1)                  |
+| `GITEA_SKIP_UNSUPPORTED_ASSETS` | Whether release assets should be skipped if Gitea server does not support them (default: false)   |
 
 ### Options
 
@@ -66,6 +67,7 @@ The user associated with the token must have push permission to the repository.
 |----------------------|--------------------------------------------------------------------|--------------------------------------|
 | `giteaUrl`           | The Gitea endpoint.                                                | `GITEA_URL` environment variable.                                                                                                       |
 | `giteaApiPathPrefix` | The Gitea API prefix.                                              | `GITEA_PREFIX` environment variable.                                                                                                 |
+| `skipUnsupportedAssets` | Whether release assets should be skipped if Gitea server does not support them | `GITEA_SKIP_UNSUPPORTED_ASSETS` environment variable.                                                                                                 |
 | `assets`             | An array of files to upload to the release. See [assets](#assets). | -                                                                                                                                  |
 
 #### assets

--- a/lib/publish.js
+++ b/lib/publish.js
@@ -18,7 +18,7 @@ module.exports = async (pluginConfig, context) => {
     nextRelease: {name, gitTag, notes},
     logger,
   } = context;
-  const {giteaToken, giteaUrl, giteaApiPathPrefix, assets} = resolveConfig(pluginConfig, context);
+  const {giteaToken, giteaUrl, giteaApiPathPrefix, assets, skipUnsupportedAssets} = resolveConfig(pluginConfig, context);
   const {owner, repo} = parseGitUrl(repositoryUrl);
   const gitea = getClient(giteaToken, giteaUrl, giteaApiPathPrefix);
   const release = {tag_name: gitTag, name, body: notes, prerelease: isPrerelease(branch)};
@@ -83,6 +83,10 @@ module.exports = async (pluginConfig, context) => {
           logger.log('API error while publishing file %s', filePath);
           if (e.hasOwnProperty('response') && e.response.body.length) {
               const errorBody = JSON.parse(e.response.body);
+              if (skipUnsupportedAssets && errorBody.message.startsWith("File type is not allowed")) {
+                logger.log('%s. Asset ignored.', errorBody.message);
+                return;
+              }
               throw getError('EGITEAAPIERROR', {message: errorBody.message});
           }
           throw e;

--- a/lib/resolve-config.js
+++ b/lib/resolve-config.js
@@ -1,15 +1,17 @@
-const {isNil, castArray} = require('lodash');
+const {castArray} = require('lodash');
 
 module.exports = (
     {
-        giteaUrl,
-        giteaApiPathPrefix,
-        assets,
+      giteaUrl,
+      giteaApiPathPrefix,
+      assets,
+      skipUnsupportedAssets
     },
     {env}
 ) => ({
-    giteaToken: env.GITEA_TOKEN,
-    giteaUrl: giteaUrl || env.GITEA_URL,
-    giteaApiPathPrefix: giteaApiPathPrefix || env.GITEA_PREFIX || '/api/v1',
-    assets: assets ? castArray(assets) : assets,
+  giteaToken: env.GITEA_TOKEN,
+  giteaUrl: giteaUrl || env.GITEA_URL,
+  giteaApiPathPrefix: giteaApiPathPrefix || env.GITEA_PREFIX || '/api/v1',
+  assets: assets ? castArray(assets) : assets,
+  skipUnsupportedAssets: skipUnsupportedAssets || Boolean(env.GITEA_SKIP_UNSUPPORTED_ASSETS) || false,
 });

--- a/lib/verify.js
+++ b/lib/verify.js
@@ -17,6 +17,7 @@ const VALIDATORS = {
   assets: isArrayOf(
     asset => isStringOrStringArray(asset) || (isPlainObject(asset) && isStringOrStringArray(asset.path))
   ),
+  skipUnsupportedAssets: option => typeof option === 'boolean',
 };
 
 module.exports = async (pluginConfig, context) => {


### PR DESCRIPTION
Adds new boolean option `skipUnsupportedAssets` and environment variable `GITEA_SKIP_UNSUPPORTED_ASSETS` for skipping assets that are not supported by Gitea. Default is false.