### PR TITLE
feat: Add support for providing additional notes at the end of the release description

### DIFF
--- a/lib/publish.js
+++ b/lib/publish.js
@@ -18,10 +18,11 @@ module.exports = async (pluginConfig, context) => {
     nextRelease: {name, gitTag, notes},
     logger,
   } = context;
-  const {giteaToken, giteaUrl, giteaApiPathPrefix, assets} = resolveConfig(pluginConfig, context);
+  const {giteaToken, giteaUrl, giteaApiPathPrefix, assets, additionalNotes} = resolveConfig(pluginConfig, context);
   const {owner, repo} = parseGitUrl(repositoryUrl);
   const gitea = getClient(giteaToken, giteaUrl, giteaApiPathPrefix);
-  const release = {tag_name: gitTag, name, body: notes, prerelease: isPrerelease(branch)};
+  const resolvedNotes = notes + (additionalNotes ? `\n\n${template(additionalNotes)(context)}` : '');
+  const release = {tag_name: gitTag, name, body: resolvedNotes, prerelease: isPrerelease(branch)};
 
   debug('release object: %O', release);
 

--- a/lib/resolve-config.js
+++ b/lib/resolve-config.js
@@ -5,6 +5,7 @@ module.exports = (
         giteaUrl,
         giteaApiPathPrefix,
         assets,
+        additionalNotes,
     },
     {env}
 ) => ({
@@ -12,4 +13,5 @@ module.exports = (
     giteaUrl: giteaUrl || env.GITEA_URL,
     giteaApiPathPrefix: giteaApiPathPrefix || env.GITEA_PREFIX || '/api/v1',
     assets: assets ? castArray(assets) : assets,
+    additionalNotes,
 });

--- a/lib/verify.js
+++ b/lib/verify.js
@@ -1,4 +1,4 @@
-const {isString, isPlainObject, isNil, isArray, isNumber} = require('lodash');
+const {isString, isPlainObject, isNil, isArray, isNumber, isUndefined} = require('lodash');
 const urlJoin = require('url-join');
 const AggregateError = require('aggregate-error');
 const parseGitUrl = require('./parse-git-url');
@@ -15,8 +15,9 @@ const VALIDATORS = {
    * @use getError.EINVALIDASSETS
    */
   assets: isArrayOf(
-    asset => isStringOrStringArray(asset) || (isPlainObject(asset) && isStringOrStringArray(asset.path))
+    asset => isStringOrStringArray(asset) || (isPlainObject(asset) && isStringOrStringArray(asset.path)),
   ),
+  additionalNotes: value => isUndefined(value) || isString(value),
 };
 
 module.exports = async (pluginConfig, context) => {

--- a/test/verify.test.js
+++ b/test/verify.test.js
@@ -188,6 +188,25 @@ test.serial('Verify package, token and repository access with alternative enviro
    t.true(gitea.isDone());
  });
 
+ test.serial('Verify "additionalNotes" is a String', async t => {
+  const owner = 'test_user';
+  const repo = 'test_repo';
+  const env = {GITEA_URL: 'https://gitea.io',GITEA_TOKEN: 'gitea_token'};
+  const additionalNotes = 'Additional notes';
+  const gitea = authenticate(env)
+    .get(`/repos/${owner}/${repo}`)
+    .reply(200, {permissions: {push: true}});
+
+  await t.notThrowsAsync(
+    verify(
+      {additionalNotes},
+      {env, options: {repositoryUrl: `git@gitea.io:${owner}/${repo}.git`}, logger: t.context.logger}
+    )
+  );
+
+  t.true(gitea.isDone());
+});
+
  test.serial('Throw SemanticReleaseError for invalid token', async t => {
    const owner = 'test_user';
    const repo = 'test_repo';


### PR DESCRIPTION
As title.

Behavior:

* new config option called `additionalNotes`, expects a string.
* Optional, no breaking change
* Inserted 2 lines down after the release notes.
* Can be templated with the same context just like other things